### PR TITLE
feat: render elevation plans

### DIFF
--- a/CabinetLibrary_2025-09-11_14-08-14.0000000.devfull/src/drawing/render-svg.ts
+++ b/CabinetLibrary_2025-09-11_14-08-14.0000000.devfull/src/drawing/render-svg.ts
@@ -1,14 +1,14 @@
 import { Box3, Camera, Group, Mesh, OrthographicCamera, Quaternion, Scene, Vector3 } from "three";
 import { SVGRenderer } from 'three/examples/jsm/renderers/SVGRenderer.js';
 
-export const renderSVG = (scene: Scene, camera: Camera, width: number, height: number): Blob => {
-    const svgRenderer = new SVGRenderer();
-    svgRenderer.setSize(width, height);
-    svgRenderer.setQuality('low');
-    svgRenderer.setPrecision(0);
-    svgRenderer.domElement.innerHTML = '';
-    svgRenderer.render(scene, camera);
-    const svgData = svgRenderer.domElement.outerHTML;
+export const renderSVG = (scene: Scene, camera: Camera, width: number, height: number, svgRenderer?: SVGRenderer): Blob => {
+    const renderer = svgRenderer ?? new SVGRenderer();
+    renderer.setSize(width, height);
+    renderer.setQuality('low');
+    renderer.setPrecision(0);
+    renderer.domElement.innerHTML = '';
+    renderer.render(scene, camera);
+    const svgData = renderer.domElement.outerHTML;
     return new Blob([svgData], { type: 'image/svg+xml' });
 }
 

--- a/CabinetLibrary_2025-09-11_14-08-14.0000000.devfull/src/main.ts
+++ b/CabinetLibrary_2025-09-11_14-08-14.0000000.devfull/src/main.ts
@@ -15,7 +15,7 @@ import {
 	IBomOrderLineDataJson,
 	IOrderData,
 } from './lib/internal/order_outputs';
-import { AssignParts, exportModel, exportFloorPlan, IVisualPart, PartSpecialType } from './render';
+import { AssignParts, exportModel, exportPlans, IVisualPart, PartSpecialType } from './render';
 import jsonUrl from './test-orders.json?url';
 import { BomOutputData, DisplaySettings, DisplaySettingsType, OutputData } from './types/custom-types';
 import { getSelectionsByAttrId } from './lib/internal/selections';
@@ -802,16 +802,16 @@ const onDownload3d = async (): Promise<void> => {
 };
 
 const onDownload2d = async (): Promise<void> => {
-	const blob = await exportFloorPlan();
-	const url = URL.createObjectURL(blob!);
-	const anchorElement = document.createElement('a');
-	anchorElement.href = url;
-
-	anchorElement.download = 'scene.svg';
-
-	anchorElement.click();
-	anchorElement.remove();
-	URL.revokeObjectURL(url);
+	const exportedPlans = await exportPlans();
+	for (const exportedPlan of exportedPlans) {
+		const url = URL.createObjectURL(exportedPlan.blob!);
+		const anchorElement = document.createElement('a');
+		anchorElement.href = url;
+		anchorElement.download = `${exportedPlan.name}.svg`;
+		anchorElement.click();
+		anchorElement.remove();
+		URL.revokeObjectURL(url);
+	}
 };
 
 const onExecuteCheck = async (): Promise<void> => {

--- a/CabinetLibrary_2025-09-11_14-08-14.0000000.devfull/src/render.ts
+++ b/CabinetLibrary_2025-09-11_14-08-14.0000000.devfull/src/render.ts
@@ -119,15 +119,37 @@ export async function exportModel() {
 	);
 }
 
-export async function exportFloorPlan() {
+export interface PlanExport {
+	name: string;
+	blob: Blob;
+}
+
+export async function exportPlans(): Promise<PlanExport[]> {
 	const svgScene = newFloorPlanScene(scene);
 	const margin = 100;
 	const sceneBox = new Box3().setFromObject(svgScene);
 	const sceneSize = sceneBox.getSize(new Vector3()).addScalar(2 * margin);
 	const floorPlanOrientation = new Quaternion()
-		.setFromAxisAngle(new Vector3(1, 0, 0), MathUtils.degToRad(-90));
+		.setFromAxisAngle(new Vector3(1, 0, 0), MathUtils.degToRad(-90));	
 	const floorPlanCamera = newPlanCamera(floorPlanOrientation, sceneBox, margin);
-	return renderSVG(svgScene, floorPlanCamera, sceneSize.x, sceneSize.z);
+	const elevationCamera = newPlanCamera(new Quaternion(), sceneBox, margin);
+	const sideElevationOrientation = new Quaternion()
+		.setFromAxisAngle(new Vector3(0, 1, 0), MathUtils.degToRad(90));	
+	const sideElevationCamera = newPlanCamera(sideElevationOrientation, sceneBox, margin);
+	return [ 
+		{
+			'name': 'floor-plan',
+			'blob': renderSVG(svgScene, floorPlanCamera, sceneSize.x, sceneSize.z),
+		},
+		{
+			'name': 'elevation',
+			'blob': renderSVG(svgScene, elevationCamera, sceneSize.x, sceneSize.y),
+		},
+		{
+			'name': 'side-elevation',
+			'blob': renderSVG(svgScene, sideElevationCamera, sceneSize.z, sceneSize.y),
+		},
+	];
 }
 
 async function createPart(parent: Object3D, part: IVisualPart, showOpen: boolean, showDocking: boolean) {


### PR DESCRIPTION
This pull request updates the 2D export functionality to generate multiple SVG plans instead of just a single floor plan. The changes refactor the export logic to return all relevant plan views (floor plan, elevation, and side elevation) and update the download handler to save each plan with a descriptive filename.

**2D Plan Export Improvements:**

* Refactored the `exportFloorPlan` function in `render.ts` to `exportPlans`, which now returns an array of `PlanExport` objects for the floor plan, elevation, and side elevation, each with a name and SVG blob.
* Updated the 2D download handler in `main.ts` (`onDownload2d`) to iterate over all exported plans and trigger downloads for each, using their respective names for filenames.

**API and Import Updates:**

* Changed imports in `main.ts` to use `exportPlans` instead of `exportFloorPlan`.

**Rendering Logic Enhancement:**

* Modified `renderSVG` in `render-svg.ts` to accept an optional `SVGRenderer` parameter, improving flexibility for rendering multiple SVGs in succession.