### PR TITLE
feat: draw walls

### DIFF
--- a/CabinetLibrary_2025-09-11_14-08-14.0000000.devfull/src/drawing/render-svg.ts
+++ b/CabinetLibrary_2025-09-11_14-08-14.0000000.devfull/src/drawing/render-svg.ts
@@ -1,11 +1,29 @@
-import { Box3, Camera, Group, Mesh, OrthographicCamera, Quaternion, Scene, Vector3 } from "three";
+import { Box3, BoxGeometry, Camera, EdgesGeometry, Group, LineBasicMaterial, LineSegments, MathUtils, Mesh, MeshBasicMaterial, OrthographicCamera, Quaternion, Scene, Vector3 } from "three";
 import { SVGRenderer } from 'three/examples/jsm/renderers/SVGRenderer.js';
+import room from './room.json';
+
+export interface PosContourSegment {
+  angle?: number | null;
+  cmd: string;
+  height?: number | null;
+  thickness?: number | null;
+  type?: string | null;
+  x: number;
+  y: number;
+}
+
+export interface PosContour {
+  level: number;
+  segments: PosContourSegment[];
+}
 
 export const renderSVG = (scene: Scene, camera: Camera, width: number, height: number, svgRenderer?: SVGRenderer): Blob => {
     const renderer = svgRenderer ?? new SVGRenderer();
     renderer.setSize(width, height);
     renderer.setQuality('low');
     renderer.setPrecision(0);
+    renderer.domElement.style.display = 'block';
+    renderer.domElement.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
     renderer.domElement.innerHTML = '';
     renderer.render(scene, camera);
     const svgData = renderer.domElement.outerHTML;
@@ -33,15 +51,91 @@ export const newPlanCamera = (orientation: Quaternion, sceneBox: Box3, margin: n
 }
 
 export const newFloorPlanScene = (scene3d: Scene): Scene => {
-const svgScene = scene3d.clone();
+    const svgScene = scene3d.clone();
+    setPositionOfPosGroup(svgScene);
+	addWallGeometryToScene(svgScene);
     svgScene.traverse((node) => {
         if (node instanceof Mesh) {
             node.visible = false;
         } else if (node instanceof Group) {
             if (node.name.startsWith('part-Drilling')) {
                 node.visible = false;
+            } else if (node.name === 'walls') {
+                node.visible = true;
             }
         }
     });
     return svgScene;
+}
+
+export const setPositionOfPosGroup = (scene: Scene): void => {
+    const posGroup = scene.getObjectByName('pos-group');
+    if (!posGroup) {
+        return;
+    }
+    const groupPos = {
+        pos: [4815.000228700228, 0, -3765.000178827904],
+        rotationY: 270.00001282431185,
+    };
+    posGroup.position.set(groupPos.pos[0], groupPos.pos[1], groupPos.pos[2]);
+	posGroup.rotation.y = MathUtils.degToRad(groupPos.rotationY);
+}
+
+export const addWallGeometryToScene = (scene: Scene): void => {
+    const roomData = room as Array<PosContour>;
+    if (!roomData?.length) {
+        return;
+    }
+    const wallGroup = new Group();
+    wallGroup.name = 'walls';
+    scene.add(wallGroup);
+
+    for (const contour of roomData) {
+        for (let segmentI = 1; segmentI < contour.segments.length; segmentI++) {
+            const segment = contour.segments[segmentI];
+            const prevSegment = contour.segments[segmentI - 1];
+            if (segment.cmd !== 'L' || segment.type !== 'wall' || !segment.height || !segment.thickness) {
+               continue;
+            }
+            const segmentGroup = new WallSegment(prevSegment, segment);
+            wallGroup.add(segmentGroup);
+        }
+    }
+}
+
+export class WallSegment extends Group {
+    public direction: Vector3;
+    public wallLength: number;
+    public rotationY: number;
+    public normalToWall: Vector3;
+
+    constructor(from: PosContourSegment, to: PosContourSegment) {
+        super();
+        const thickness = to.thickness ?? 120;
+        const height = to.height ?? 2800;
+        const segmentStart = new Vector3(from.x, 0, from.y);
+        const segmentEnd = new Vector3(to.x, 0, to.y);
+        this.direction = new Vector3().subVectors(segmentEnd, segmentStart);
+        this.wallLength = this.direction.length();  
+        this.direction.normalize();
+        this.rotationY = Math.atan2(this.direction.z, this.direction.x);
+        this.normalToWall = new Vector3(-this.direction.z, 0, this.direction.x);
+        this._createGeometry(segmentStart, segmentEnd, height, thickness);
+    }
+
+    private _createGeometry(segmentStart: Vector3, segmentEnd: Vector3, height: number, thickness: number): void {
+        const segmentEndBack = segmentEnd.clone().addScaledVector(this.normalToWall, thickness);
+        const segmentCenter = new Vector3().addVectors(segmentStart, segmentEndBack).multiplyScalar(0.5);
+        this.position.copy(segmentCenter);
+        this.position.y = height * 0.5;
+        this.rotation.y = this.rotationY;
+
+        const wallGeometry = new BoxGeometry(this.wallLength, height, thickness);
+        const wallMesh = new Mesh(wallGeometry, new MeshBasicMaterial({ color: 0xcccccc }));
+        this.add(wallMesh);
+
+        const edgeGeometry = new EdgesGeometry(wallGeometry);
+        const wireframe = new LineSegments(edgeGeometry, new LineBasicMaterial({ color: 0x000000, linewidth: 1 }));
+        this.add(wireframe);
+    }
 }

--- a/CabinetLibrary_2025-09-11_14-08-14.0000000.devfull/src/drawing/room.json
+++ b/CabinetLibrary_2025-09-11_14-08-14.0000000.devfull/src/drawing/room.json
@@ -1,0 +1,52 @@
+[
+  {
+    "level": 0,
+    "segments": [
+      {
+        "angle": null,
+        "cmd": "M",
+        "height": null,
+        "thickness": null,
+        "type": null,
+        "x": 4815,
+        "y": 1235
+      },
+      {
+        "angle": null,
+        "cmd": "L",
+        "height": 2800,
+        "thickness": 120,
+        "type": "wall",
+        "x": 4815,
+        "y": -3765
+      },
+      {
+        "angle": null,
+        "cmd": "L",
+        "height": 2800,
+        "thickness": 120,
+        "type": "wall",
+        "x": -685,
+        "y": -3765
+      },
+      {
+        "angle": null,
+        "cmd": "L",
+        "height": 2800,
+        "thickness": 120,
+        "type": "wall",
+        "x": -685,
+        "y": 1235
+      },
+      {
+        "angle": null,
+        "cmd": "L",
+        "height": 2800,
+        "thickness": 120,
+        "type": "wall",
+        "x": 4815,
+        "y": 1235
+      }
+    ]
+  }
+]

--- a/CabinetLibrary_2025-09-11_14-08-14.0000000.devfull/src/render.ts
+++ b/CabinetLibrary_2025-09-11_14-08-14.0000000.devfull/src/render.ts
@@ -1,5 +1,5 @@
 import { logError } from './lib/internal/logging';
-import { newFloorPlanScene, newPlanCamera, renderSVG } from './drawing/render-svg';
+import { addWallGeometryToScene, newFloorPlanScene, newPlanCamera, renderSVG, setPositionOfPosGroup } from './drawing/render-svg';
 import {
 	ArrowHelper,
 	AxesHelper,
@@ -412,9 +412,12 @@ export async function AssignParts(
 	lastHighlightIds = JSON.parse(JSON.stringify(highlightIds));
 
 	if (pas) {
+		const posGroup = new Group();
+		posGroup.name = 'pos-group';
+		scene.add(posGroup);
 		for (const part of pas) {
 			//place the parts which have no group assigned
-			await createPart(scene, part, showOpen, showDocking);
+			await createPart(posGroup, part, showOpen, showDocking);
 		}
 	}
 

--- a/CabinetLibrary_2025-09-11_14-08-14.0000000.devfull/src/render.ts
+++ b/CabinetLibrary_2025-09-11_14-08-14.0000000.devfull/src/render.ts
@@ -1,5 +1,5 @@
 import { logError } from './lib/internal/logging';
-import { addWallGeometryToScene, newFloorPlanScene, newPlanCamera, renderSVG, setPositionOfPosGroup } from './drawing/render-svg';
+import { findWallSegmentsAroundGroup, hideAllOtherWallSegments, newFloorPlanScene, newPlanCamera, renderSVG } from './drawing/render-svg';
 import {
 	ArrowHelper,
 	AxesHelper,
@@ -132,24 +132,31 @@ export async function exportPlans(): Promise<PlanExport[]> {
 	const floorPlanOrientation = new Quaternion()
 		.setFromAxisAngle(new Vector3(1, 0, 0), MathUtils.degToRad(-90));	
 	const floorPlanCamera = newPlanCamera(floorPlanOrientation, sceneBox, margin);
-	const elevationCamera = newPlanCamera(new Quaternion(), sceneBox, margin);
-	const sideElevationOrientation = new Quaternion()
-		.setFromAxisAngle(new Vector3(0, 1, 0), MathUtils.degToRad(90));	
-	const sideElevationCamera = newPlanCamera(sideElevationOrientation, sceneBox, margin);
-	return [ 
-		{
-			'name': 'floor-plan',
-			'blob': renderSVG(svgScene, floorPlanCamera, sceneSize.x, sceneSize.z),
-		},
-		{
-			'name': 'elevation',
-			'blob': renderSVG(svgScene, elevationCamera, sceneSize.x, sceneSize.y),
-		},
-		{
-			'name': 'side-elevation',
-			'blob': renderSVG(svgScene, sideElevationCamera, sceneSize.z, sceneSize.y),
-		},
-	];
+
+	const plans: PlanExport[] = [];
+	plans.push({
+		'name': 'floor-plan',
+		'blob': renderSVG(svgScene, floorPlanCamera, sceneSize.x, sceneSize.z),
+	});
+
+	const wallsSegmentsAroundGroup = findWallSegmentsAroundGroup(svgScene);
+	if (!wallsSegmentsAroundGroup) {
+		return plans;
+	}
+	hideAllOtherWallSegments(svgScene, wallsSegmentsAroundGroup);
+	for (let segmentIndex = 0; segmentIndex < wallsSegmentsAroundGroup.length; segmentIndex++) {
+		const wallSegment = wallsSegmentsAroundGroup[segmentIndex];
+		const rotationY = (-wallSegment.rotationY - Math.PI / 2) % (2 * Math.PI);
+		const elevationOrientation = new Quaternion()
+			.setFromAxisAngle(new Vector3(0, 1, 0), rotationY);
+		const elevationCamera = newPlanCamera(elevationOrientation, sceneBox, margin);
+		const sizeVector = new Vector3(sceneSize.x, 0, sceneSize.z).applyQuaternion(elevationOrientation);
+		plans.push({
+			'name': `elevation-${segmentIndex}`,
+			'blob': renderSVG(svgScene, elevationCamera, Math.abs(sizeVector.x), sceneSize.y),
+		});
+	}
+	return plans;
 }
 
 async function createPart(parent: Object3D, part: IVisualPart, showOpen: boolean, showDocking: boolean) {


### PR DESCRIPTION
This pull request introduces major improvements to the rendering of floor plans and wall elevations in the cabinet library. The changes add support for loading room geometry from a JSON file, programmatically constructing wall segments in the scene, and generating elevation views for each wall segment near the cabinet group. The export logic is refactored to dynamically create elevation views based on scene geometry, rather than using static camera orientations.

**Room geometry and wall rendering enhancements:**

* Added `room.json` containing room contour and wall segment data, and new TypeScript interfaces (`PosContour`, `PosContourSegment`) to represent this geometry. [[1]](diffhunk://#diff-97e8ebe043942dd5a5ba6cea018b8e2360cde478ad731bf801245758b6766d6cR1-R52) [[2]](diffhunk://#diff-5bead0b93b441f52bf2edf7a0d3d2b6eaf84e64d12b36552a5f969496f1b4940L1-R26)
* Implemented logic to parse `room.json` and generate wall geometry in the scene, including the new `WallSegment` class for wall construction and interaction.
* Added functions to position the cabinet group (`pos-group`) and to find wall segments close to this group, enabling context-aware elevation rendering.

**Export and rendering logic improvements:**

* Refactored the export logic to generate a floor plan and elevation views for each wall segment near the cabinet group, replacing the previous static elevation and side elevation exports.
* Updated part assignment to add all cabinet parts to the `pos-group`, ensuring correct positioning and grouping for subsequent wall proximity calculations.